### PR TITLE
Rework the tests for use with Python3

### DIFF
--- a/ldap_test/test/tests.py
+++ b/ldap_test/test/tests.py
@@ -1,64 +1,82 @@
-#!/usr/bin/env python
-
-import ldap
 import sys
+import unittest
+from os import path
+
+sys.path.insert(0, path.abspath(path.join(path.dirname(__file__), '..', '..')))
+
+import ldap3
 
 from ldap_test import LdapServer
 
 
-if __name__ == "__main__":
-
-    server = LdapServer()
-
-    try:
+class LdapServerTest(unittest.TestCase):
+    def test_default(self):
+        server = LdapServer()
         server.start()
 
         dn = server.config['bind_dn']
         pw = server.config['password']
 
-        con = ldap.initialize('ldap://localhost:%s' % (server.config['port'],))
-        con.simple_bind_s(dn, pw)
+        srv = ldap3.Server('localhost', port=server.config['port'])
+        conn = ldap3.Connection(srv, user=dn, password=pw, auto_bind=True)
 
         base_dn = server.config['base']['dn']
         filter = '(objectclass=domain)'
         attrs = ['dc']
 
-        print con.search_s(base_dn, ldap.SCOPE_SUBTREE, filter, attrs)
+        conn.search(base_dn, filter, attributes=attrs)
 
-    finally:
+        self.assertEqual(conn.response, [{
+            'dn': 'dc=example,dc=com',
+            'raw_attributes': {'dc': [b'example']},
+            'attributes': {'dc': ['example']},
+            'type': 'searchResEntry'
+        }])
+
         server.stop()
 
-    server = LdapServer({
-        'port': 3333,
-        'bind_dn': 'cn=admin,dc=zoldar,dc=net',
-        'password': 'pass1',
-        'base': {'objectclass': ['domain'],
-                 'dn': 'dc=zoldar,dc=net',
-                 'attributes': {'dc': 'zoldar'}},
-        'entries': [
-            {'objectclass': 'domain',
-             'dn': 'dc=users,dc=zoldar,dc=net',
-             'attributes': {'dc': 'users'}},
-            {'objectclass': 'organization',
-             'dn': 'o=foocompany,dc=users,dc=zoldar,dc=net',
-             'attributes': {'o': 'foocompany'}},
-        ]
-    })
-
-    try:
+    def test_config(self):
+        server = LdapServer({
+            'port': 3333,
+            'bind_dn': 'cn=admin,dc=zoldar,dc=net',
+            'password': 'pass1',
+            'base': {
+                'objectclass': ['domain'],
+                'dn': 'dc=zoldar,dc=net',
+                'attributes': {'dc': 'zoldar'}
+            },
+            'entries': [{
+                'objectclass': ['domain'],
+                'dn': 'dc=users,dc=zoldar,dc=net',
+                'attributes': {'dc': 'users'}
+            }, {
+                'objectclass': ['organization'],
+                'dn': 'o=foocompany,dc=users,dc=zoldar,dc=net',
+                'attributes': {'o': 'foocompany'}
+            }],
+        })
         server.start()
 
         dn = "cn=admin,dc=zoldar,dc=net"
         pw = "pass1"
 
-        con = ldap.initialize('ldap://localhost:3333')
-        con.simple_bind_s(dn, pw)
+        srv = ldap3.Server('localhost', port=3333)
+        conn = ldap3.Connection(srv, user=dn, password=pw, auto_bind=True)
 
         base_dn = 'dc=zoldar,dc=net'
-        filter = '(objectclass=domain)'
+        filter = '(objectclass=organization)'
         attrs = ['o']
 
-        print con.search_s(base_dn, ldap.SCOPE_SUBTREE, filter, attrs)
+        conn.search(base_dn, filter, attributes=attrs)
 
-    finally:
+        self.assertEqual(conn.response, [{
+            'dn': 'o=foocompany,dc=users,dc=zoldar,dc=net',
+            'raw_attributes': {'o': [b'foocompany']},
+            'attributes': {'o': ['foocompany']},
+            'type': 'searchResEntry'
+        }])
+
         server.stop()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py34
+skipsdist = true
+
+[testenv]
+commands = python ldap_test/test/tests.py
+deps = 
+    py4j
+    python3-ldap


### PR DESCRIPTION
Not sure if you want to merge this, but here are some tests I wrote when fixing the python3 support.

It uses the python3-ldap library because unlike python-ldap it supports Python3, and Tox makes it a lot easier to test both Python 2 & 3 at the same time.
