### PR TITLE
Add .tox to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
 /dist
 /python_ldap_test.egg-info
+/.tox
 *.pyc


### PR DESCRIPTION
Sorry, forgot to include the .tox directory in gitignore in my initial pull request
