### PR TITLE
Add support for running multiple LDAP servers

### DIFF
--- a/ldap_test/server.py
+++ b/ldap_test/server.py
@@ -182,14 +182,13 @@ class LdapServer(object):
         if JVM_GATEWAY is None:
             JVM_GATEWAY = run_jvm_gateway()
 
-        self.gateway = JVM_GATEWAY
-        self.server = self.gateway.entry_point
-        self.config, self.config_obj = ConfigBuilder(
-            self.gateway
-        ).build_from(config)
+        self.server = JVM_GATEWAY.entry_point
+        self.config, self._config_obj = \
+            ConfigBuilder(JVM_GATEWAY).build_from(config)
+        self.server_id = self.server.create(self._config_obj)
 
     def start(self):
-        self.server.start(self.config_obj)
+        self.server.start(self.server_id)
 
     def stop(self):
-        self.server.stop()
+        self.server.stop(self.server_id)

--- a/ldap_test/test/tests.py
+++ b/ldap_test/test/tests.py
@@ -78,5 +78,65 @@ class LdapServerTest(unittest.TestCase):
 
         server.stop()
 
+    def test_multiple_instances(self):
+        servers = {}
+        for sid in (1, 2):
+            domain = 'example{0}'.format(sid)
+            servers[sid] = LdapServer({
+                'port': 10389 + (sid * 1000),
+                'bind_dn': 'cn=admin,dc={0},dc=com'.format(domain),
+                'base': {
+                    'objectclass': ['domain'],
+                    'dn': 'dc={0},dc=com'.format(domain),
+                    'attributes': {'dc': domain}
+                },
+            })
+            servers[sid].start()
+
+        search_filter = '(objectclass=domain)'
+        attrs = ['dc']
+
+        # server1
+        dn = servers[1].config['bind_dn']
+        pw = servers[1].config['password']
+        base_dn = servers[1].config['base']['dn']
+        port = servers[1].config['port']
+
+        srv = ldap3.Server('localhost', port=port)
+        conn = ldap3.Connection(srv, user=dn, password=pw, auto_bind=True)
+        conn.search(base_dn, search_filter, attributes=attrs)
+
+        self.assertEqual(conn.response, [{
+            'dn': 'dc=example1,dc=com',
+            'raw_attributes': {'dc': [b'example1']},
+            'attributes': {'dc': ['example1']},
+            'type': 'searchResEntry'
+        }])
+
+        conn.unbind()
+
+        # server2
+        dn = servers[2].config['bind_dn']
+        pw = servers[2].config['password']
+        base_dn = servers[2].config['base']['dn']
+        port = servers[2].config['port']
+
+        srv = ldap3.Server('localhost', port=port)
+        conn = ldap3.Connection(srv, user=dn, password=pw, auto_bind=True)
+        conn.search(base_dn, search_filter, attributes=attrs)
+
+        self.assertEqual(conn.response, [{
+            'dn': 'dc=example2,dc=com',
+            'raw_attributes': {'dc': [b'example2']},
+            'attributes': {'dc': ['example2']},
+            'type': 'searchResEntry'
+        }])
+
+        conn.unbind()
+
+        for server in servers.values():
+            server.stop()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The ldap-test-server-py4j java server now provides support for running multiple LDAP servers at the same time, so lets take advantage of that so we perform tests that may require more than one LDAP server.

This patch requires an updated version of ldap-test-server-py4j that includes the pull request: https://github.com/zoldar/ldap-test-server-py4j/pull/1
