### PR TITLE
Added support for bdist_rpm rpm building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,18 @@ setup(
     package_data={
         '': ['*.txt'],
         'ldap_test': ['*.jar'],
-    }
+    },
+    options={
+        'bdist_rpm': {
+            'build_requires':[
+                'python',
+                'python-setuptools',
+                'py4j',
+            ],
+            'requires':[
+                'python',
+                'py4j',
+            ],
+        },
+    },
 )


### PR DESCRIPTION
Showing that this works from my desktop:

[krasmussen@kras-desktop python-ldap-test]$ python ./setup.py bdist_rpm
running bdist_rpm
running egg_info
creating python_ldap_test.egg-info
writing requirements to python_ldap_test.egg-info/requires.txt
writing python_ldap_test.egg-info/PKG-INFO
writing top-level names to python_ldap_test.egg-info/top_level.txt
writing dependency_links to python_ldap_test.egg-info/dependency_links.txt
writing pbr to python_ldap_test.egg-info/pbr.json
writing manifest file 'python_ldap_test.egg-info/SOURCES.txt'
reading manifest file 'python_ldap_test.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'python_ldap_test.egg-info/SOURCES.txt'
creating build
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/rpm
creating build/bdist.linux-x86_64/rpm/SOURCES
creating build/bdist.linux-x86_64/rpm/SPECS
creating build/bdist.linux-x86_64/rpm/BUILD
creating build/bdist.linux-x86_64/rpm/RPMS
creating build/bdist.linux-x86_64/rpm/SRPMS
writing 'build/bdist.linux-x86_64/rpm/SPECS/python-ldap-test.spec'
running sdist
warning: sdist: standard file not found: should have one of README, README.rst, README.txt

running check
creating python-ldap-test-0.2.0
creating python-ldap-test-0.2.0/ldap_test
creating python-ldap-test-0.2.0/ldap_test/test
creating python-ldap-test-0.2.0/python_ldap_test.egg-info
making hard links in python-ldap-test-0.2.0...
hard linking CHANGES.txt -> python-ldap-test-0.2.0
hard linking LICENSE.txt -> python-ldap-test-0.2.0
hard linking MANIFEST.in -> python-ldap-test-0.2.0
hard linking README.md -> python-ldap-test-0.2.0
hard linking setup.py -> python-ldap-test-0.2.0
hard linking ldap_test/__init__.py -> python-ldap-test-0.2.0/ldap_test
hard linking ldap_test/ldap-test-server-0.0.3-SNAPSHOT-jar-with-dependencies.jar -> python-ldap-test-0.2.0/ldap_test
hard linking ldap_test/server.py -> python-ldap-test-0.2.0/ldap_test
hard linking ldap_test/test/__init__.py -> python-ldap-test-0.2.0/ldap_test/test
hard linking ldap_test/test/tests.py -> python-ldap-test-0.2.0/ldap_test/test
hard linking python_ldap_test.egg-info/PKG-INFO -> python-ldap-test-0.2.0/python_ldap_test.egg-info
hard linking python_ldap_test.egg-info/SOURCES.txt -> python-ldap-test-0.2.0/python_ldap_test.egg-info
hard linking python_ldap_test.egg-info/dependency_links.txt -> python-ldap-test-0.2.0/python_ldap_test.egg-info
hard linking python_ldap_test.egg-info/pbr.json -> python-ldap-test-0.2.0/python_ldap_test.egg-info
hard linking python_ldap_test.egg-info/requires.txt -> python-ldap-test-0.2.0/python_ldap_test.egg-info
hard linking python_ldap_test.egg-info/top_level.txt -> python-ldap-test-0.2.0/python_ldap_test.egg-info
Writing python-ldap-test-0.2.0/setup.cfg
creating dist
Creating tar archive
removing 'python-ldap-test-0.2.0' (and everything under it)
copying dist/python-ldap-test-0.2.0.tar.gz -> build/bdist.linux-x86_64/rpm/SOURCES
building RPMs
rpmbuild -ba --define _topdir /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm --clean build/bdist.linux-x86_64/rpm/SPECS/python-ldap-test.spec
Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.K1YkhN
+ umask 022
+ cd /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILD
+ cd /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILD
+ rm -rf python-ldap-test-0.2.0
+ /usr/bin/tar -xvvf -
+ /usr/bin/gzip -dc /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/SOURCES/python-ldap-test-0.2.0.tar.gz
drwxrwxr-x krasmussen/krasmussen 0 2015-11-11 15:20 python-ldap-test-0.2.0/
drwxrwxr-x krasmussen/krasmussen 0 2015-11-11 15:20 python-ldap-test-0.2.0/ldap_test/
drwxrwxr-x krasmussen/krasmussen 0 2015-11-11 15:20 python-ldap-test-0.2.0/ldap_test/test/
-rw-rw-r-- krasmussen/krasmussen 0 2015-11-11 15:13 python-ldap-test-0.2.0/ldap_test/test/__init__.py
-rw-rw-r-- krasmussen/krasmussen 4339 2015-11-11 15:13 python-ldap-test-0.2.0/ldap_test/test/tests.py
-rw-rw-r-- krasmussen/krasmussen   50 2015-11-11 15:13 python-ldap-test-0.2.0/ldap_test/__init__.py
-rw-rw-r-- krasmussen/krasmussen 1547170 2015-11-11 15:13 python-ldap-test-0.2.0/ldap_test/ldap-test-server-0.0.3-SNAPSHOT-jar-with-dependencies.jar
-rwxrwxr-x krasmussen/krasmussen    5679 2015-11-11 15:13 python-ldap-test-0.2.0/ldap_test/server.py
drwxrwxr-x krasmussen/krasmussen       0 2015-11-11 15:20 python-ldap-test-0.2.0/python_ldap_test.egg-info/
-rw-rw-r-- krasmussen/krasmussen    8442 2015-11-11 15:20 python-ldap-test-0.2.0/python_ldap_test.egg-info/PKG-INFO
-rw-rw-r-- krasmussen/krasmussen     449 2015-11-11 15:20 python-ldap-test-0.2.0/python_ldap_test.egg-info/SOURCES.txt
-rw-rw-r-- krasmussen/krasmussen       1 2015-11-11 15:20 python-ldap-test-0.2.0/python_ldap_test.egg-info/dependency_links.txt
-rw-rw-r-- krasmussen/krasmussen      47 2015-11-11 15:20 python-ldap-test-0.2.0/python_ldap_test.egg-info/pbr.json
-rw-rw-r-- krasmussen/krasmussen      12 2015-11-11 15:20 python-ldap-test-0.2.0/python_ldap_test.egg-info/requires.txt
-rw-rw-r-- krasmussen/krasmussen      10 2015-11-11 15:20 python-ldap-test-0.2.0/python_ldap_test.egg-info/top_level.txt
-rw-rw-r-- krasmussen/krasmussen     269 2015-11-11 15:13 python-ldap-test-0.2.0/CHANGES.txt
-rw-rw-r-- krasmussen/krasmussen    1073 2015-11-11 15:13 python-ldap-test-0.2.0/LICENSE.txt
-rw-rw-r-- krasmussen/krasmussen      56 2015-11-11 15:13 python-ldap-test-0.2.0/MANIFEST.in
-rw-rw-r-- krasmussen/krasmussen    6339 2015-11-11 15:13 python-ldap-test-0.2.0/README.md
-rwxrwxr-x krasmussen/krasmussen    1171 2015-11-11 15:19 python-ldap-test-0.2.0/setup.py
-rw-rw-r-- krasmussen/krasmussen    8442 2015-11-11 15:20 python-ldap-test-0.2.0/PKG-INFO
-rw-rw-r-- krasmussen/krasmussen      59 2015-11-11 15:20 python-ldap-test-0.2.0/setup.cfg
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd python-ldap-test-0.2.0
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ exit 0
Executing(%build): /bin/sh -e /var/tmp/rpm-tmp.In3cQJ
+ umask 022
+ cd /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILD
+ cd python-ldap-test-0.2.0
+ python setup.py build
running build
running build_py
creating build
creating build/lib
creating build/lib/ldap_test
copying ldap_test/__init__.py -> build/lib/ldap_test
copying ldap_test/server.py -> build/lib/ldap_test
creating build/lib/ldap_test/test
copying ldap_test/test/__init__.py -> build/lib/ldap_test/test
copying ldap_test/test/tests.py -> build/lib/ldap_test/test
copying ldap_test/ldap-test-server-0.0.3-SNAPSHOT-jar-with-dependencies.jar -> build/lib/ldap_test
+ exit 0
Executing(%install): /bin/sh -e /var/tmp/rpm-tmp.An4F5H
+ umask 022
+ cd /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILD
+ '[' /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64 '!=' / ']'
+ rm -rf /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64
++ dirname /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64
+ mkdir -p /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT
+ mkdir /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64
+ cd python-ldap-test-0.2.0
+ python setup.py install --single-version-externally-managed -O1 --root=/home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64 --record=INSTALLED_FILES
running install
running build
running build_py
running install_lib
creating /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr
creating /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib
creating /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7
creating /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages
creating /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test
copying build/lib/ldap_test/__init__.py -> /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test
copying build/lib/ldap_test/server.py -> /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test
creating /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/test
copying build/lib/ldap_test/test/__init__.py -> /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/test
copying build/lib/ldap_test/test/tests.py -> /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/test
copying build/lib/ldap_test/ldap-test-server-0.0.3-SNAPSHOT-jar-with-dependencies.jar -> /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test
byte-compiling /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/__init__.py to __init__.pyc
byte-compiling /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/server.py to server.pyc
byte-compiling /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/test/__init__.py to __init__.pyc
byte-compiling /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/test/tests.py to tests.pyc
writing byte-compilation script '/tmp/tmpEzhkAC.py'
/usr/bin/python -O /tmp/tmpEzhkAC.py
removing /tmp/tmpEzhkAC.py
running install_egg_info
running egg_info
writing requirements to python_ldap_test.egg-info/requires.txt
writing python_ldap_test.egg-info/PKG-INFO
writing top-level names to python_ldap_test.egg-info/top_level.txt
writing dependency_links to python_ldap_test.egg-info/dependency_links.txt
writing pbr to python_ldap_test.egg-info/pbr.json
reading manifest file 'python_ldap_test.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'python_ldap_test.egg-info/SOURCES.txt'
Copying python_ldap_test.egg-info to /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/python_ldap_test-0.2.0-py2.7.egg-info
running install_scripts
writing list of installed files to 'INSTALLED_FILES'
+ /usr/lib/rpm/find-debuginfo.sh --strict-build-id -m --run-dwz --dwz-low-mem-die-limit 10000000 --dwz-max-die-limit 110000000 /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILD/python-ldap-test-0.2.0
/usr/lib/rpm/sepdebugcrcfix: Updated 0 CRC32s, 0 CRC32s did match.
find: 'debug': No such file or directory
+ /usr/lib/rpm/check-buildroot
+ /usr/lib/rpm/brp-compress
+ /usr/lib/rpm/brp-strip-static-archive /usr/bin/strip
+ /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
Bytecompiling .py files below /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7 using /usr/bin/python2.7
+ /usr/lib/rpm/brp-python-hardlink
+ /usr/lib/rpm/redhat/brp-java-repack-jars
Processing files: python-ldap-test-0.2.0-1.noarch
warning: File listed twice: /usr/lib/python2.7/site-packages/python_ldap_test-0.2.0-py2.7.egg-info/PKG-INFO
warning: File listed twice: /usr/lib/python2.7/site-packages/python_ldap_test-0.2.0-py2.7.egg-info/SOURCES.txt
warning: File listed twice: /usr/lib/python2.7/site-packages/python_ldap_test-0.2.0-py2.7.egg-info/dependency_links.txt
warning: File listed twice: /usr/lib/python2.7/site-packages/python_ldap_test-0.2.0-py2.7.egg-info/pbr.json
warning: File listed twice: /usr/lib/python2.7/site-packages/python_ldap_test-0.2.0-py2.7.egg-info/requires.txt
warning: File listed twice: /usr/lib/python2.7/site-packages/python_ldap_test-0.2.0-py2.7.egg-info/top_level.txt
[INFO osgi.prov] input: ['/home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/ldap-test-server-0.0.3-SNAPSHOT-jar-with-dependencies.jar']
[INFO osgi.req] input: ['/home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64/usr/lib/python2.7/site-packages/ldap_test/ldap-test-server-0.0.3-SNAPSHOT-jar-with-dependencies.jar']
Provides: python-ldap-test = 0.2.0-1
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PartialHardlinkSets) <= 4.0.4-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Requires: python(abi) = 2.7
Checking for unpackaged file(s): /usr/lib/rpm/check-files /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64
Wrote: /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/SRPMS/python-ldap-test-0.2.0-1.src.rpm
Wrote: /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/RPMS/noarch/python-ldap-test-0.2.0-1.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.LCNGbd
+ umask 022
+ cd /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILD
+ cd python-ldap-test-0.2.0
+ rm -rf /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILDROOT/python-ldap-test-0.2.0-1.x86_64
+ exit 0
Executing(--clean): /bin/sh -e /var/tmp/rpm-tmp.J9VykI
+ umask 022
+ cd /home/krasmussen/Desktop/python-ldap-test/build/bdist.linux-x86_64/rpm/BUILD
+ rm -rf python-ldap-test-0.2.0
+ exit 0
moving build/bdist.linux-x86_64/rpm/SRPMS/python-ldap-test-0.2.0-1.src.rpm -> dist
moving build/bdist.linux-x86_64/rpm/RPMS/noarch/python-ldap-test-0.2.0-1.noarch.rpm -> dist
[krasmussen@kras-desktop python-ldap-test]$ sudo yum -y install ./dist/python-ldap-test-0.2.0-1.noarch.rpm 
[sudo] password for krasmussen: 
Yum command has been deprecated, redirecting to '/usr/bin/dnf -y install ./dist/python-ldap-test-0.2.0-1.noarch.rpm'.
See 'man dnf' and 'man yum2dnf' for more information.
To transfer transaction metadata from yum to DNF, run:
'dnf install python-dnf-plugins-extras-migrate && dnf-2 migrate'

Failed to synchronize cache for repo 'dev_centos_7_x86_64_ecm' from 'http://yum.secureserver.net/reposdev/centos/7/x86_64/ecm': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried, disabling.
Last metadata expiration check performed 2:14:32 ago on Wed Nov 11 13:09:21 2015.
Dependencies resolved.
======================================================================================================================================
 Package                              Arch                       Version                       Repository                        Size
======================================================================================================================================
Installing:
 python-ldap-test                     noarch                     0.2.0-1                       @commandline                     1.4 M

Transaction Summary
======================================================================================================================================
Install  1 Package

Total size: 1.4 M
Installed size: 1.5 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Installing  : python-ldap-test-0.2.0-1.noarch                                                                                   1/1 
  Verifying   : python-ldap-test-0.2.0-1.noarch                                                                                   1/1 

Installed:
  python-ldap-test.noarch 0.2.0-1                                                                                                     

Complete!
[krasmussen@kras-desktop python-ldap-test]$ cd ~
[krasmussen@kras-desktop ~]$ python
Python 2.7.10 (default, Sep 24 2015, 17:50:09) 
[GCC 5.1.1 20150618 (Red Hat 5.1.1-4)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> from ldap_test import LdapServer
>>> server = LdapServer()
Gateway server started on port 25333!
>>> 