### PR TITLE
Fix installation on systems were locales are not properly configured

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,18 @@
+import codecs
 from distutils.core import setup
-from setuptools.command.install import install
 
+
+def read(fname):
+    '''
+    Read a file from the directory where setup.py resides
+    '''
+    with codecs.open(fname, encoding='utf-8') as rfh:
+        return rfh.read()
 
 try:
-    description = open('README.txt').read()
+    description = read('README.txt')
 except:
-    description = open('README.md').read()
+    description = read('README.md')
 
 
 setup(
@@ -19,7 +26,7 @@ setup(
     description=('Tool for testing code speaking with LDAP server. Allows to easily'
                  ' configure and run an embedded, in-memory LDAP server. Uses'
                  ' UnboundID LDAP SDK through Py4J.'),
-    keywords = ['testing', 'tests', 'test', 'ldap'],
+    keywords=['testing', 'tests', 'test', 'ldap'],
     long_description=description,
     install_requires=[
         "py4j >= 0.10.2.1",


### PR DESCRIPTION
```
12:34:38     Function: pip.installed
12:34:38       Result: False
12:34:38      Comment: Failed to install packages: python-ldap-test. Error: Collecting python-ldap-test
12:34:38                 Downloading python-ldap-test-0.2.2.tar.gz (1.5MB)
12:34:38                   Complete output from command python setup.py egg_info:
12:34:38                   Traceback (most recent call last):
12:34:38                     File "/tmp/pip-build-fs3cb0xf/python-ldap-test/setup.py", line 6, in <module>
12:34:38                       description = open('README.txt').read()
12:34:38                     File "/var/lib/jenkins/workspace/raas/pr/1327/.virtualenvs/Raas-Py3.4.3/lib/python3.4/encodings/ascii.py", line 26, in decode
12:34:38                       return codecs.ascii_decode(input, self.errors)[0]
12:34:38                   UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 6411: ordinal not in range(128)
12:34:38                   
12:34:38                   During handling of the above exception, another exception occurred:
12:34:38                   
12:34:38                   Traceback (most recent call last):
12:34:38                     File "<string>", line 1, in <module>
12:34:38                     File "/tmp/pip-build-fs3cb0xf/python-ldap-test/setup.py", line 8, in <module>
12:34:38                       description = open('README.md').read()
12:34:38                     File "/var/lib/jenkins/workspace/raas/pr/1327/.virtualenvs/Raas-Py3.4.3/lib/python3.4/encodings/ascii.py", line 26, in decode
12:34:38                       return codecs.ascii_decode(input, self.errors)[0]
12:34:38                   UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 6361: ordinal not in range(128)
12:34:38                   
12:34:38                   ---------------------------------------- Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-fs3cb0xf/python-ldap-test/
12:34:38      Started: 11:34:24.820997
12:34:38     Duration: 2051.799 ms
12:34:38      Changes:
```