### PR TITLE
Create new connection objects on connection retry

### DIFF
--- a/ldap_test/server.py
+++ b/ldap_test/server.py
@@ -83,12 +83,12 @@ def run_jvm_server(gateway_port=DEFAULT_GATEWAY_PORT):
 
 class SlowGatewayClient(GatewayClient):
     def _create_connection(self):
-        parameters = GatewayParameters(address=self.address,
-                                       port=self.port,
-                                       auto_close=self.auto_close,
-                                       eager_load=True)
-        connection = MuffledGatewayConnection(parameters, self.gateway_property)
         while True:
+            parameters = GatewayParameters(address=self.address,
+                                           port=self.port,
+                                           auto_close=self.auto_close,
+                                           eager_load=True)
+            connection = MuffledGatewayConnection(parameters, self.gateway_property)
             connection_success = False
             try:
                 connection.start()


### PR DESCRIPTION
This fixes a situation where on macOS the python proxy retries to connect to the java gateway over and over again.
