### PR TITLE
Introduced an optional delay between JVM server start and py4j gatewa…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.3.1, 2017-05-19 -- Introduced optional delay between JVM and py4j gateway start to solve issue # 14
 v0.3.0, 2016-09-11 -- Support for configuring custom ports for gateway and proxy
 v0.2.2, 2016-07-27 -- Update py4j to make library work with recent python versions
 v0.2.1, 2015-12-30 -- More informative error on missing java executable

--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ The format of entry in `entries` as well as `base` is following:
                             # 'ou': ['Value1', 'Value2', ...]
      }
     }
+    
+## MacOS
+For some reason, while running on MacOS, you can experience problems if the JVM doesn't start quickly enough for the py4j gateway to connect, and it goes into an infinite hang.
+
+If you're experiencing this problem, you can set an interval between the JVM startup and the py4j gateway by passing 'java_delay=n' to LdapServer() where 'n' is the number of seconds to wait.  Typically a wait of even 1 second is enough for java to spin up and be ready for the gateway.
+
+To be clear, the following:
+
+    server = LdapServer(config={...}, java_delay=1)
+    
+will cause a 1 second delay between starting the JVM and creating the py4j gateway, and all should be well.  
+
+In tests, a delay of even 0.5 seconds can be enough, though 0.1 seconds is not.  The exact cause of this problem is unknown.  More information on this 'feature' while running on a Mac is welcome.
 
 ## Running Java gateway and proxy on non-standard ports
 
@@ -214,6 +227,7 @@ Any issues (be it bugs, feature requests or anything else) can be reported throu
 - John Kristensen ([https://github.com/jerrykan](https://github.com/jerrykan))
 - Kevin Rasmussen ([https://github.com/krasmussen](https://github.com/krasmussen))
 - Pedro Algarvio ([https://github.com/s0undt3ch](https://github.com/s0undt3ch))
+- Nik Ogura ([https://github.com/nikogura])(https://github.com/nikogura)
 
 ## License
 

--- a/ldap_test/server.py
+++ b/ldap_test/server.py
@@ -195,11 +195,16 @@ class ConfigBuilder(object):
 class LdapServer(object):
     def __init__(self, config=None,
                  java_gateway_port=DEFAULT_GATEWAY_PORT,
-                 python_proxy_port=DEFAULT_PYTHON_PROXY_PORT):
+                 python_proxy_port=DEFAULT_PYTHON_PROXY_PORT, java_delay=None):
         global SERVER_PROCESS, JVM_GATEWAY
 
         if SERVER_PROCESS is None:
             SERVER_PROCESS = run_jvm_server(java_gateway_port)
+
+        # Added to introduce a delay between starting the SERVER_PROCESS and the JVM_GATEWAY if desired.
+        # This seems to be a problem on some MacOS systems, and without it you end up with an infinite hang.
+        if java_delay:
+            time.sleep(java_delay)
 
         if JVM_GATEWAY is None:
             JVM_GATEWAY = run_jvm_gateway(java_gateway_port, python_proxy_port)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ except:
 
 setup(
     name='python-ldap-test',
-    version='0.3.0',
+    version='0.3.1',
     author='Adrian Gruntkowski',
     author_email='adrian.gruntkowski@gmail.com',
     packages=['ldap_test', 'ldap_test.test'],


### PR DESCRIPTION
…y start that resolves an infinite hang on LdapServer() creation on some MacOS systems.