### PR TITLE
Fix run_jvm_server for windows

### DIFF
--- a/ldap_test/server.py
+++ b/ldap_test/server.py
@@ -72,7 +72,7 @@ def run_jvm_server(gateway_port=DEFAULT_GATEWAY_PORT):
         raise Exception("'java' executable not found in system path!")
 
     try:
-        return subprocess.Popen("exec %s -jar %s --port %s" % (
+        return subprocess.Popen('"%s" -jar "%s" --port "%s"' % (
             jre_executable,
             JVM_SERVER_BIN,
             gateway_port), shell=True)


### PR DESCRIPTION
It also fixes potential quoting issues if there is a space in the executable path, i.e. `C:\Program Files\Java`.
Resolves #17

I don't think exec was really needed. Was there a reason for it originally? It's normally used to replace the current process, which is pointless if it's the only thing being called.